### PR TITLE
fix: fixed preprocess function name bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/
 node_modules/
 .env
+.DS_Store

--- a/rapidkit_theme.theme
+++ b/rapidkit_theme.theme
@@ -29,7 +29,7 @@ function rapidkit_theme_preprocess_layout(array &$variables): void
     $variables['attributes']['class'] = 'layout';
 }
 
-function rapidkit_theme_theme_suggestions_alter(array &$suggestions, array $variables, $hook): void
+function rapidkit_theme_theme_suggestions_alter(array &$suggestions, array $variables, string $hook): void
 {
     // Add suggestion target for specific form.
     if ($hook === 'form') {
@@ -44,7 +44,7 @@ function rapidkit_theme_theme_suggestions_alter(array &$suggestions, array $vari
     }
 }
 
-function rapidkit_preprocess_block(array &$variables): void
+function rapidkit_theme_preprocess_block(array &$variables): void
 {
     if (isset($variables['elements']['#id'])) {
         $block = Block::load($variables['elements']['#id']);


### PR DESCRIPTION
Fixes [ZUDF-150](https://zucommunications.atlassian.net/browse/ZUDF-150)

## Changes proposed in this pull request
- Fixed preprocess function name
- Added a type annotation to resolve phpstan error

### Context 
The preprocess function did not have the correct name and because of that, the function name  was not correctly replaced by the theme name when generating a new theme. This caused phpstan to throw errors.

[ZUDF-150]: https://zucommunications.atlassian.net/browse/ZUDF-150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ