### PR TITLE
chore: added spaces between tags and {{

### DIFF
--- a/components/form/form-element-label--inline/form-element-label--inline.twig
+++ b/components/form/form-element-label--inline/form-element-label--inline.twig
@@ -6,5 +6,5 @@
   'ml-2 text-sm font-medium text-gray-900 dark:text-gray-300'
 ] %}
 {% if title is not empty or required -%}
-  <label{{ attributes.addClass(classes) }}>{{ title }}</label>
+  <label {{ attributes.addClass(classes) }}>{{ title }}</label>
 {%- endif %}

--- a/components/form/form-element-label/form-element-label.twig
+++ b/components/form/form-element-label/form-element-label.twig
@@ -24,5 +24,5 @@
 %}
 
 {% if title is not empty or required -%}
-  <label{{ attributes.addClass(classes) }}>{{ title }}</label>
+  <label {{ attributes.addClass(classes) }}>{{ title }}</label>
 {%- endif %}

--- a/components/form/form-element/form-element.twig
+++ b/components/form/form-element/form-element.twig
@@ -68,7 +68,7 @@
 {% set children_html %}{% block children_html %}{{ children }}{% endblock %}{% endset %}
 {% set label_html %}{% block label_html %}{{ label }}{% endblock %}{% endset %}
 
-<div{{ attributes.addClass(classes) }}>
+<div {{ attributes.addClass(classes) }}>
     {% if type in ['checkbox', 'radio'] %}
         <div class="flex items-start mb-1">
             {{ children_html }}
@@ -100,7 +100,7 @@
         </p>
     {% endif %}
     {% if description_display in ['after', 'invisible'] and description.content %}
-        <div{{ description.attributes|default(create_attribute()).addClass(description_classes) }}>
+        <div {{ description.attributes|default(create_attribute()).addClass(description_classes) }}>
             {{ description.content }}
         </div>
     {% endif %}

--- a/components/form/input/input.twig
+++ b/components/form/input/input.twig
@@ -10,4 +10,4 @@
  * @see template_preprocess_input()
  */
 #}
-<input{{ attributes.addClass(classes) }} />{{ children }}
+<input {{ attributes.addClass(classes) }} />{{ children }}

--- a/components/form/select/select.twig
+++ b/components/form/select/select.twig
@@ -11,7 +11,7 @@
  */
 #}
 {% apply spaceless %}
-    <select{{ attributes.addClass('bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500') }}>
+    <select {{ attributes.addClass('bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500') }}>
         {% for option in options %}
             {% if option.type == 'optgroup' %}
                 <optgroup label="{{ option.label }}">

--- a/components/form/textarea/textarea.twig
+++ b/components/form/textarea/textarea.twig
@@ -20,6 +20,6 @@
     'block p-2.5 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500'
 ]
 %}
-<div{{ wrapper_attributes.addClass('form-textarea-wrapper') }}>
-    <textarea{{ attributes.addClass(classes) }}>{{ value }}</textarea>
+<div {{ wrapper_attributes.addClass('form-textarea-wrapper') }}>
+    <textarea {{ attributes.addClass(classes) }}>{{ value }}</textarea>
 </div>

--- a/templates/block/block--search-form-block.html.twig
+++ b/templates/block/block--search-form-block.html.twig
@@ -34,10 +34,10 @@
     'container-inline',
   ]
 %}
-<div{{ attributes.addClass(classes) }}>
+<div {{ attributes.addClass(classes) }}>
   {{ title_prefix }}
   {% if label %}
-    <h2{{ title_attributes }}>{{ label }}</h2>
+    <h2 {{ title_attributes }}>{{ label }}</h2>
   {% endif %}
   {{ title_suffix }}
   {% block content %}

--- a/templates/block/block--system-menu-block.html.twig
+++ b/templates/block/block--system-menu-block.html.twig
@@ -47,7 +47,7 @@
     {% set title_attributes = title_attributes.addClass('visually-hidden') %}
   {% endif %}
   {{ title_prefix }}
-  <h2{{ title_attributes.setAttribute('id', heading_id) }}>{{ configuration.label }}</h2>
+  <h2 {{ title_attributes.setAttribute('id', heading_id) }}>{{ configuration.label }}</h2>
   {{ title_suffix }}
 
   {# Menu. #}

--- a/templates/block/block.html.twig
+++ b/templates/block/block.html.twig
@@ -33,10 +33,10 @@
     'block-' ~ plugin_id|clean_class,
   ]
 %}
-<div{{ attributes.addClass(classes) }}>
+<div {{ attributes.addClass(classes) }}>
   {{ title_prefix }}
   {% if label %}
-    <h2{{ title_attributes }}>{{ label }}</h2>
+    <h2 {{ title_attributes }}>{{ label }}</h2>
   {% endif %}
   {{ title_suffix }}
   {% block content %}

--- a/templates/content-edit/file-managed-file.html.twig
+++ b/templates/content-edit/file-managed-file.html.twig
@@ -17,6 +17,6 @@
     'form-managed-file',
   ]
 %}
-<div{{ attributes.addClass(classes) }}>
+<div {{ attributes.addClass(classes) }}>
   {{ element }}
 </div>

--- a/templates/content-edit/filter-guidelines.html.twig
+++ b/templates/content-edit/filter-guidelines.html.twig
@@ -23,7 +23,7 @@
     'filter-guidelines-' ~ format.id,
   ]
 %}
-<div{{ attributes.addClass(classes) }}>
+<div {{ attributes.addClass(classes) }}>
   <h4 class="label">{{ format.label }}</h4>
   {{ tips }}
 </div>

--- a/templates/content-edit/filter-tips.html.twig
+++ b/templates/content-edit/filter-tips.html.twig
@@ -33,7 +33,7 @@
           'filter-' ~ name|clean_class,
         ]
       %}
-      <div{{ tip.attributes.addClass(tip_classes) }}>
+      <div {{ tip.attributes.addClass(tip_classes) }}>
       <h3>{{ tip.name }}</h3>
     {% endif %}
 
@@ -45,7 +45,7 @@
             long ? 'filter-' ~ item.id|replace({'/': '-'}),
           ]
         %}
-        <li{{ item.attributes.addClass(item_classes) }}>{{ item.tip }}</li>
+        <li {{ item.attributes.addClass(item_classes) }}>{{ item.tip }}</li>
       {% endfor %}
       </ul>
     {% endif %}

--- a/templates/content-edit/image-widget.html.twig
+++ b/templates/content-edit/image-widget.html.twig
@@ -10,7 +10,7 @@
  * @see template_preprocess_image_widget()
  */
 #}
-<div{{ attributes }}>
+<div {{ attributes }}>
   {% if data.preview %}
     <div class="image-preview">
       {{ data.preview }}

--- a/templates/content-edit/text-format-wrapper.html.twig
+++ b/templates/content-edit/text-format-wrapper.html.twig
@@ -21,6 +21,6 @@
         aria_description ? 'description',
       ]
     %}
-    <div{{ attributes.addClass(classes) }}>{{ description }}</div>
+    <div {{ attributes.addClass(classes) }}>{{ description }}</div>
   {% endif %}
 </div>

--- a/templates/content/comment.html.twig
+++ b/templates/content/comment.html.twig
@@ -76,7 +76,7 @@
     author_id and author_id == commented_entity.getOwnerId() ? 'by-' ~ commented_entity.getEntityTypeId() ~ '-author',
   ]
 %}
-<article{{ attributes.addClass(classes) }}>
+<article {{ attributes.addClass(classes) }}>
   {#
     Hide the "new" indicator by default, let a piece of JavaScript ask the
     server which comments are new for the user. Rendering the final "new"
@@ -100,10 +100,10 @@
     {{ permalink }}
   </footer>
 
-  <div{{ content_attributes.addClass('content') }}>
+  <div {{ content_attributes.addClass('content') }}>
     {% if title %}
       {{ title_prefix }}
-      <h3{{ title_attributes }}>{{ title }}</h3>
+      <h3 { title_attributes }}>{{ title }}</h3>
       {{ title_suffix }}
     {% endif %}
     {{ content }}

--- a/templates/content/media.html.twig
+++ b/templates/content/media.html.twig
@@ -20,7 +20,7 @@
     view_mode ? 'media--view-mode-' ~ view_mode|clean_class,
   ]
 %}
-<article{{ attributes.addClass(classes) }}>
+<article {{ attributes.addClass(classes) }}>
   {{ title_suffix.contextual_links }}
   {% if content %}
     {{ content }}

--- a/templates/content/node.html.twig
+++ b/templates/content/node.html.twig
@@ -78,11 +78,11 @@
   ]
 %}
 {{ attach_library('rapidkit_theme/node') }}
-<article{{ attributes.addClass(classes) }}>
+<article {{ attributes.addClass(classes) }}>
 
   {{ title_prefix }}
   {% if label and not page %}
-    <h2{{ title_attributes }}>
+    <h2 {{ title_attributes }}>
       <a href="{{ url }}" rel="bookmark">{{ label }}</a>
     </h2>
   {% endif %}
@@ -91,14 +91,14 @@
   {% if display_submitted %}
     <footer class="node__meta">
       {{ author_picture }}
-      <div{{ author_attributes.addClass('node__submitted') }}>
+      <div {{ author_attributes.addClass('node__submitted') }}>
         {% trans %}Submitted by {{ author_name }} on {{ date }}{% endtrans %}
         {{ metadata }}
       </div>
     </footer>
   {% endif %}
 
-  <div{{ content_attributes.addClass('node__content') }}>
+  <div {{ content_attributes.addClass('node__content') }}>
     {{ content }}
   </div>
 

--- a/templates/content/page-title.html.twig
+++ b/templates/content/page-title.html.twig
@@ -14,6 +14,6 @@
 #}
 {{ title_prefix }}
 {% if title %}
-  <h1{{ title_attributes.addClass('page-title') }}>{{ title }}</h1>
+  <h1 {{ title_attributes.addClass('page-title') }}>{{ title }}</h1>
 {% endif %}
 {{ title_suffix }}

--- a/templates/content/search-result.html.twig
+++ b/templates/content/search-result.html.twig
@@ -58,13 +58,13 @@
 #}
 {{ attach_library('rapidkit_theme/search-results') }}
 {{ title_prefix }}
-<h3{{ title_attributes.addClass('search-result__title') }}>
+<h3 {{ title_attributes.addClass('search-result__title') }}>
   <a href="{{ url }}">{{ title }}</a>
 </h3>
 {{ title_suffix }}
 <div class="search-result__snippet-info">
   {% if snippet %}
-    <p{{ content_attributes.addClass('search-result__snippet') }}>{{ snippet }}</p>
+    <p {{ content_attributes.addClass('search-result__snippet') }}>{{ snippet }}</p>
   {% endif %}
   {% if info %}
     <p class="search-result__info">{{ info }}</p>

--- a/templates/content/taxonomy-term.html.twig
+++ b/templates/content/taxonomy-term.html.twig
@@ -29,7 +29,7 @@
     'vocabulary-' ~ term.bundle|clean_class,
   ]
 %}
-<div{{ attributes.setAttribute('id', 'taxonomy-term-' ~ term.id).addClass(classes) }}>
+<div {{ attributes.setAttribute('id', 'taxonomy-term-' ~ term.id).addClass(classes) }}>
   {{ title_prefix }}
   {% if name and not page %}
     <h2><a href="{{ url }}">{{ name }}</a></h2>

--- a/templates/dataset/item-list.html.twig
+++ b/templates/dataset/item-list.html.twig
@@ -24,14 +24,14 @@
   {%- set attributes = attributes.addClass('item-list__' ~ context.list_style) %}
 {% endif %}
 {% if items or empty -%}
-  <div{{ wrapper_attributes.addClass('item-list') }}>
+  <div {{ wrapper_attributes.addClass('item-list') }}>
     {%- if title is not empty -%}
       <h3>{{ title }}</h3>
     {%- endif -%}
     {%- if items -%}
       <{{ list_type }}{{ attributes }}>
         {%- for item in items -%}
-          <li{{ item.attributes }}>{{ item.value }}</li>
+          <li {{ item.attributes }}>{{ item.value }}</li>
         {%- endfor -%}
       </{{ list_type }}>
     {%- else -%}

--- a/templates/dataset/table.html.twig
+++ b/templates/dataset/table.html.twig
@@ -39,20 +39,20 @@
  * @see template_preprocess_table()
  */
 #}
-<table{{ attributes }}>
+<table {{ attributes }}>
   {% if caption %}
     <caption>{{ caption }}</caption>
   {% endif %}
 
   {% for colgroup in colgroups %}
     {% if colgroup.cols %}
-      <colgroup{{ colgroup.attributes }}>
+      <colgroup {{ colgroup.attributes }}>
         {% for col in colgroup.cols %}
           <col{{ col.attributes }} />
         {% endfor %}
       </colgroup>
     {% else %}
-      <colgroup{{ colgroup.attributes }} />
+      <colgroup {{ colgroup.attributes }} />
     {% endif %}
   {% endfor %}
 

--- a/templates/field/field--comment.html.twig
+++ b/templates/field/field--comment.html.twig
@@ -40,10 +40,10 @@
     label_display == 'visually_hidden' ? 'visually-hidden',
   ]
 %}
-<section{{ attributes.addClass(classes) }}>
+<section {{ attributes.addClass(classes) }}>
   {% if comments and not label_hidden %}
     {{ title_prefix }}
-    <h2{{ title_attributes.addClass(title_classes) }}>{{ label }}</h2>
+    <h2 {{ title_attributes.addClass(title_classes) }}>{{ label }}</h2>
     {{ title_suffix }}
   {% endif %}
 

--- a/templates/field/field--node--body--home-page.html.twig
+++ b/templates/field/field--node--body--home-page.html.twig
@@ -56,24 +56,24 @@
 <div class="prose max-w-none">
   {% if label_hidden %}
     {% if multiple %}
-      <div{{ attributes.addClass(classes, 'field__items') }}>
+      <div {{ attributes.addClass(classes, 'field__items') }}>
         {% for item in items %}
-          <div{{ item.attributes.addClass('field__item') }}>{{ item.content }}</div>
+          <div {{ item.attributes.addClass('field__item') }}>{{ item.content }}</div>
         {% endfor %}
       </div>
     {% else %}
       {% for item in items %}
-        <div{{ attributes.addClass(classes, 'field__item') }}>{{ item.content }}</div>
+        <div {{ attributes.addClass(classes, 'field__item') }}>{{ item.content }}</div>
       {% endfor %}
     {% endif %}
   {% else %}
-    <div{{ attributes.addClass(classes) }}>
-      <div{{ title_attributes.addClass(title_classes) }}>{{ label }}</div>
+    <div {{ attributes.addClass(classes) }}>
+      <div {{ title_attributes.addClass(title_classes) }}>{{ label }}</div>
       {% if multiple %}
       <div class="field__items">
         {% endif %}
         {% for item in items %}
-          <div{{ item.attributes.addClass('field__item') }}>{{ item.content }}</div>
+          <div {{ item.attributes.addClass('field__item') }}>{{ item.content }}</div>
         {% endfor %}
         {% if multiple %}
       </div>

--- a/templates/field/field--node--created.html.twig
+++ b/templates/field/field--node--created.html.twig
@@ -36,7 +36,7 @@
     'field--label-' ~ label_display,
   ]
 %}
-<span{{ attributes.addClass(classes) }}>
+<span {{ attributes.addClass(classes) }}>
   {%- for item in items -%}
     {{ item.content }}
   {%- endfor -%}

--- a/templates/field/field--node--title.html.twig
+++ b/templates/field/field--node--title.html.twig
@@ -36,7 +36,7 @@
     'field--label-' ~ label_display,
   ]
 %}
-<span{{ attributes.addClass(classes) }}>
+<span {{ attributes.addClass(classes) }}>
   {%- for item in items -%}
     {{ item.content }}
   {%- endfor -%}

--- a/templates/field/field--node--uid.html.twig
+++ b/templates/field/field--node--uid.html.twig
@@ -36,7 +36,7 @@
     'field--label-' ~ label_display,
   ]
 %}
-<span{{ attributes.addClass(classes) }}>
+<span {{ attributes.addClass(classes) }}>
   {%- for item in items -%}
     {{ item.content }}
   {%- endfor -%}

--- a/templates/field/field.html.twig
+++ b/templates/field/field.html.twig
@@ -55,24 +55,24 @@
 
 {% if label_hidden %}
   {% if multiple %}
-    <div{{ attributes.addClass(classes, 'field__items') }}>
+    <div {{ attributes.addClass(classes, 'field__items') }}>
       {% for item in items %}
-        <div{{ item.attributes.addClass('field__item') }}>{{ item.content }}</div>
+        <div {{ item.attributes.addClass('field__item') }}>{{ item.content }}</div>
       {% endfor %}
     </div>
   {% else %}
     {% for item in items %}
-      <div{{ attributes.addClass(classes, 'field__item') }}>{{ item.content }}</div>
+      <div {{ attributes.addClass(classes, 'field__item') }}>{{ item.content }}</div>
     {% endfor %}
   {% endif %}
 {% else %}
-  <div{{ attributes.addClass(classes) }}>
-    <div{{ title_attributes.addClass(title_classes) }}>{{ label }}</div>
+  <div {{ attributes.addClass(classes) }}>
+    <div {{ title_attributes.addClass(title_classes) }}>{{ label }}</div>
     {% if multiple %}
       <div class="field__items">
     {% endif %}
     {% for item in items %}
-      <div{{ item.attributes.addClass('field__item') }}>{{ item.content }}</div>
+      <div {{ item.attributes.addClass('field__item') }}>{{ item.content }}</div>
     {% endfor %}
     {% if multiple %}
       </div>

--- a/templates/field/file-link.html.twig
+++ b/templates/field/file-link.html.twig
@@ -13,4 +13,4 @@
  */
 #}
 {{ attach_library('rapidkit_theme/file') }}
-<span{{ attributes }}>{{ icon }} {{ link }}</span>
+<span {{ attributes }}>{{ icon }} {{ link }}</span>

--- a/templates/field/image.html.twig
+++ b/templates/field/image.html.twig
@@ -16,4 +16,4 @@ set classes = [
   'w-full'
 ]
 %}
-<img{{ attributes.addClass(classes) }} />
+<img {{ attributes.addClass(classes) }} />

--- a/templates/field/time.html.twig
+++ b/templates/field/time.html.twig
@@ -19,4 +19,4 @@
  * @see http://www.w3.org/TR/html5-author/the-time-element.html#attr-time-datetime
  */
 #}
-<time{{ attributes.addClass('datetime') }}>{{ text }}</time>
+<time {{ attributes.addClass('datetime') }}>{{ text }}</time>

--- a/templates/form/checkboxes.html.twig
+++ b/templates/form/checkboxes.html.twig
@@ -12,4 +12,4 @@
  @todo: remove this file once https://www.drupal.org/node/1819284 is resolved.
  This is identical to core/modules/system/templates/container.html.twig
 #}
-<div{{ attributes.addClass('form-checkboxes') }}>{{ children }}</div>
+<div {{ attributes.addClass('form-checkboxes') }}>{{ children }}</div>

--- a/templates/form/container.html.twig
+++ b/templates/form/container.html.twig
@@ -25,4 +25,4 @@
     has_parent ? 'form-wrapper',
   ]
 %}
-<div{{ attributes.addClass(classes) }}>{{ children }}</div>
+<div {{ attributes.addClass(classes) }}>{{ children }}</div>

--- a/templates/form/datetime-form.html.twig
+++ b/templates/form/datetime-form.html.twig
@@ -10,6 +10,6 @@
  * @see template_preprocess_datetime_form()
  */
 #}
-<div{{ attributes.addClass('container-inline') }}>
+<div {{ attributes.addClass('container-inline') }}>
   {{ content }}
 </div>

--- a/templates/form/datetime-wrapper.html.twig
+++ b/templates/form/datetime-wrapper.html.twig
@@ -21,7 +21,7 @@
   ]
 %}
 {% if title %}
-  <h4{{ title_attributes.addClass(title_classes) }}>{{ title }}</h4>
+  <h4 {{ title_attributes.addClass(title_classes) }}>{{ title }}</h4>
 {% endif %}
 {{ content }}
 {% if errors %}
@@ -30,7 +30,7 @@
   </div>
 {% endif %}
 {% if description %}
-  <div{{ description_attributes.addClass('description') }}>
+  <div {{ description_attributes.addClass('description') }}>
     {{ description }}
   </div>
 {% endif %}

--- a/templates/form/details.html.twig
+++ b/templates/form/details.html.twig
@@ -15,7 +15,7 @@
  * @see template_preprocess_details()
  */
 #}
-<details{{ attributes }}>
+<details {{ attributes }}>
   {%- if title -%}
     {%
       set summary_classes = [
@@ -23,7 +23,7 @@
         required ? 'form-required',
       ]
     %}
-    <summary{{ summary_attributes.addClass(summary_classes) }}>{{ title }}</summary>
+    <summary {{ summary_attributes.addClass(summary_classes) }}>{{ title }}</summary>
   {%- endif -%}
   <div class="details-wrapper">
     {% if errors %}

--- a/templates/form/field-multiple-value-form.html.twig
+++ b/templates/form/field-multiple-value-form.html.twig
@@ -26,10 +26,10 @@
       'form-item'
     ]
   %}
-  <div{{ attributes.addClass(classes) }}>
+  <div {{ attributes.addClass(classes) }}>
     {{ table }}
     {% if description.content %}
-      <div{{ description.attributes.addClass('description') }} >{{ description.content }}</div>
+      <div {{ description.attributes.addClass('description') }} >{{ description.content }}</div>
     {% endif %}
     {% if button %}
       <div class="clearfix">{{ button }}</div>

--- a/templates/form/fieldset.html.twig
+++ b/templates/form/fieldset.html.twig
@@ -28,7 +28,7 @@
     'form-wrapper',
   ]
 %}
-<fieldset{{ attributes.addClass(classes) }}>
+<fieldset {{ attributes.addClass(classes) }}>
   {%
     set legend_span_classes = [
       'fieldset-legend',
@@ -37,8 +37,8 @@
     ]
   %}
   {#  Always wrap fieldset legends in a <span> for CSS positioning. #}
-  <legend{{ legend.attributes }}>
-    <span{{ legend_span.attributes.addClass(legend_span_classes) }}>{{ legend.title }}</span>
+  <legend {{ legend.attributes }}>
+    <span {{ legend_span.attributes.addClass(legend_span_classes) }}>{{ legend.title }}</span>
   </legend>
   <div class="fieldset-wrapper">
     {% if errors %}
@@ -54,7 +54,7 @@
       <span class="field-suffix">{{ suffix }}</span>
     {% endif %}
     {% if description.content %}
-      <div{{ description.attributes.addClass('description') }}>{{ description.content }}</div>
+      <div {{ description.attributes.addClass('description') }}>{{ description.content }}</div>
     {% endif %}
   </div>
 </fieldset>

--- a/templates/form/form--user-login-form.html.twig
+++ b/templates/form/form--user-login-form.html.twig
@@ -10,6 +10,6 @@
  * @see template_preprocess_form()
  */
 #}
-<form{{ attributes.addClass('') }}>
+<form {{ attributes.addClass('') }}>
   {{ children }}
 </form>

--- a/templates/form/form-element--checkbox.html.twig
+++ b/templates/form/form-element--checkbox.html.twig
@@ -66,7 +66,7 @@
   ]
 
 %}
-<div{{ attributes.addClass(classes) }}>
+<div {{ attributes.addClass(classes) }}>
   <div class="flex items-center">
     {% if label_display in ['before', 'invisible'] %}
       {{ label }}

--- a/templates/form/form-element-label--checkbox.html.twig
+++ b/templates/form/form-element-label--checkbox.html.twig
@@ -23,5 +23,5 @@
 %}
 
 {% if title is not empty or required -%}
-  <label{{ attributes.addClass(classes) }}>{{ title }}</label>
+  <label {{ attributes.addClass(classes) }}>{{ title }}</label>
 {%- endif %}

--- a/templates/form/form-element-label.html.twig
+++ b/templates/form/form-element-label.html.twig
@@ -23,5 +23,5 @@
 %}
 
 {% if title is not empty or required -%}
-  <label{{ attributes.addClass(classes) }}>{{ title }}</label>
+  <label {{ attributes.addClass(classes) }}>{{ title }}</label>
 {%- endif %}

--- a/templates/form/form-element.html.twig
+++ b/templates/form/form-element.html.twig
@@ -68,7 +68,7 @@
 %}
 
 
-<div{{ attributes.addClass(classes) }}>
+<div {{ attributes.addClass(classes) }}>
   {% if label_display in ['before', 'invisible'] %}
     {{ label }}
   {% endif %}
@@ -93,7 +93,7 @@
     </div>
   {% endif %}
   {% if description_display in ['after', 'invisible'] and description.content %}
-    <div{{ description.attributes.addClass(description_classes) }}>
+    <div {{ description.attributes.addClass(description_classes) }}>
       {{ description.content }}
     </div>
   {% endif %}

--- a/templates/form/form.html.twig
+++ b/templates/form/form.html.twig
@@ -10,6 +10,6 @@
  * @see template_preprocess_form()
  */
 #}
-<form{{ attributes }}>
+<for[ ]{{ attributes }}>
   {{ children }}
 </form>

--- a/templates/form/form.html.twig
+++ b/templates/form/form.html.twig
@@ -10,6 +10,6 @@
  * @see template_preprocess_form()
  */
 #}
-<for[ ]{{ attributes }}>
+<form {{ attributes }}>
   {{ children }}
 </form>

--- a/templates/form/radios.html.twig
+++ b/templates/form/radios.html.twig
@@ -10,4 +10,4 @@
  * @see template_preprocess_radios()
  */
 #}
-<div{{ attributes.addClass('form-radios') }}>{{ children }}</div>
+<div {{ attributes.addClass('form-radios') }}>{{ children }}</div>

--- a/templates/layout/html.html.twig
+++ b/templates/layout/html.html.twig
@@ -33,7 +33,7 @@
   ]
 %}
 <!DOCTYPE html>
-<html{{ html_attributes }}>
+<html {{ html_attributes }}>
   <head>
     <head-placeholder token="{{ placeholder_token }}">
     <title>{{ head_title|safe_join(' | ') }}</title>
@@ -43,7 +43,7 @@
     <css-placeholder token="{{ placeholder_token }}">
     <js-placeholder token="{{ placeholder_token }}">
   </head>
-  <body{{ attributes.addClass(body_classes) }}>
+  <body {{ attributes.addClass(body_classes) }}>
     {#
       Keyboard navigation/accessibility link to main content section in
       page.html.twig.

--- a/templates/layout/layout--fourcol-section.html.twig
+++ b/templates/layout/layout--fourcol-section.html.twig
@@ -14,7 +14,7 @@
     'mb-4'
 ] %}
 {% if content %}
-    <div{{ attributes.addClass(classes) }}>
+    <div {{ attributes.addClass(classes) }}>
 
         {% if content.first %}
             <div {{ region_attributes.first.addClass('layout__region', 'layout__region--first') }}>

--- a/templates/layout/layout--onecol.html.twig
+++ b/templates/layout/layout--onecol.html.twig
@@ -14,7 +14,7 @@
 ] %}
 
 {% if content %}
-  <div{{ attributes.addClass(classes) }}>
+  <div {{ attributes.addClass(classes) }}>
     <div {{ region_attributes.content.addClass('layout__region', 'layout__region--content') }}>
       {{ content.content }}
     </div>

--- a/templates/layout/region--breadcrumb.html.twig
+++ b/templates/layout/region--breadcrumb.html.twig
@@ -20,7 +20,7 @@
   ]
 %}
 {% if content %}
-  <div{{ attributes.addClass(classes) }}>
+  <div {{ attributes.addClass(classes) }}>
     {{ content }}
   </div>
 {% endif %}

--- a/templates/layout/region--content.html.twig
+++ b/templates/layout/region--content.html.twig
@@ -19,7 +19,7 @@
   ]
 %}
 {% if content %}
-  <div{{ attributes.addClass(classes) }}>
+  <div {{ attributes.addClass(classes) }}>
     {{ content }}
   </div>
 {% endif %}

--- a/templates/layout/region--footer.html.twig
+++ b/templates/layout/region--footer.html.twig
@@ -19,7 +19,7 @@
     'bg-gray-200'
   ]
 %}
-<div{{ attributes.addClass(classes) }}>
+<div {{ attributes.addClass(classes) }}>
   <div class="container mx-auto">
     <div class="grid gap-4 lg:grid-cols-2">
       <div class="lg:order-2">NAV:</div>

--- a/templates/layout/region--header.html.twig
+++ b/templates/layout/region--header.html.twig
@@ -21,7 +21,7 @@
 ]
 %}
 {% if content %}
-  <div{{ attributes.addClass(classes) }}>
+  <div {{ attributes.addClass(classes) }}>
     {{ content }}
   </div>
 {% endif %}

--- a/templates/layout/region--highlighted.html.twig
+++ b/templates/layout/region--highlighted.html.twig
@@ -22,7 +22,7 @@
 %}
 
 {% if content is not empty %}
-    <div{{ attributes.addClass(classes) }}>
+    <div {{ attributes.addClass(classes) }}>
         {{ content }}
     </div>
 {% endif %}

--- a/templates/layout/region.html.twig
+++ b/templates/layout/region.html.twig
@@ -19,7 +19,7 @@
   ]
 %}
 {% if content %}
-  <div{{ attributes.addClass(classes) }}>
+  <div {{ attributes.addClass(classes) }}>
     {{ content }}
   </div>
 {% endif %}

--- a/templates/navigation/links.html.twig
+++ b/templates/navigation/links.html.twig
@@ -36,16 +36,16 @@
     {%- if heading.level -%}
       <{{ heading.level }}{{ heading.attributes }}>{{ heading.text }}</{{ heading.level }}>
     {%- else -%}
-      <h2{{ heading.attributes }}>{{ heading.text }}</h2>
+      <h2 {{ heading.attributes }}>{{ heading.text }}</h2>
     {%- endif -%}
   {%- endif -%}
-  <ul{{ attributes }}>
+  <ul {{ attributes }}>
     {%- for item in links -%}
       <li{{ item.attributes }}>
         {%- if item.link -%}
           {{ item.link }}
         {%- elseif item.text_attributes -%}
-          <span{{ item.text_attributes }}>{{ item.text }}</span>
+          <span {{ item.text_attributes }}>{{ item.text }}</span>
         {%- else -%}
           {{ item.text }}
         {%- endif -%}

--- a/templates/navigation/menu-local-action.html.twig
+++ b/templates/navigation/menu-local-action.html.twig
@@ -10,4 +10,4 @@
  * @see template_preprocess_menu_local_action()
  */
 #}
-<li{{ attributes }}>{{ link }}</li>
+<li {{ attributes }}>{{ link }}</li>

--- a/templates/navigation/menu-local-task.html.twig
+++ b/templates/navigation/menu-local-task.html.twig
@@ -19,4 +19,4 @@
 {% else %}
   {% set link = link|merge({'#attributes':{'class':'inline-block p-4 border-b-2 border-transparent rounded-t-lg hover:text-gray-600 hover:border-gray-300 dark:hover:text-gray-300'}}) %}
 {% endif %}
-<li{{ attributes.addClass(is_active ? 'mr-2 is-active' : 'mr-2') }}>{{ link }}</li>
+<li {{ attributes.addClass(is_active ? 'mr-2 is-active' : 'mr-2') }}>{{ link }}</li>

--- a/templates/navigation/menu.html.twig
+++ b/templates/navigation/menu.html.twig
@@ -30,7 +30,7 @@
   {% import _self as menus %}
   {% if items %}
     {% if menu_level == 0 %}
-      <ul{{ attributes.addClass('menu') }}>
+      <ul {{ attributes.addClass('menu') }}>
     {% else %}
       <ul class="menu">
     {% endif %}
@@ -43,7 +43,7 @@
           item.in_active_trail ? 'menu-item--active-trail',
         ]
       %}
-      <li{{ item.attributes.addClass(classes) }}>
+      <li {{ item.attributes.addClass(classes) }}>
         {{ link(item.title, item.url) }}
         {% if item.below %}
           {{ menus.menu_links(item.below, attributes, menu_level + 1) }}

--- a/templates/navigation/vertical-tabs.html.twig
+++ b/templates/navigation/vertical-tabs.html.twig
@@ -10,4 +10,4 @@
  * @see template_preprocess_vertical_tabs()
  */
 #}
-<div{{ attributes.setAttribute('data-vertical-tabs-panes', TRUE) }}>{{ children }}</div>
+<div {{ attributes.setAttribute('data-vertical-tabs-panes', TRUE) }}>{{ children }}</div>

--- a/templates/user/user.html.twig
+++ b/templates/user/user.html.twig
@@ -16,7 +16,7 @@
  * @see template_preprocess_user()
  */
 #}
-<article{{ attributes.addClass('profile') }}>
+<article {{ attributes.addClass('profile') }}>
   {% if content %}
     {{- content -}}
   {% endif %}

--- a/templates/user/username.html.twig
+++ b/templates/user/username.html.twig
@@ -23,7 +23,7 @@
  */
 #}
 {% if link_path -%}
-  <a{{ attributes.addClass('username') }}>{{ name }}{{ extra }}</a>
+  <a {{ attributes.addClass('username') }}>{{ name }}{{ extra }}</a>
 {%- else -%}
-  <span{{ attributes }}>{{ name }}{{ extra }}</span>
+  <span {{ attributes }}>{{ name }}{{ extra }}</span>
 {%- endif -%}

--- a/templates/views/views-view-grid.html.twig
+++ b/templates/views/views-view-grid.html.twig
@@ -51,12 +51,12 @@
 {% if title %}
   <h3>{{ title }}</h3>
 {% endif %}
-<div{{ attributes.addClass(classes) }}>
+<div {{ attributes.addClass(classes) }}>
   {% if options.alignment == 'horizontal' %}
     {% for row in items %}
-      <div{{ row.attributes.addClass(row_classes, options.row_class_default ? 'row-' ~ loop.index) }}>
+      <div {{ row.attributes.addClass(row_classes, options.row_class_default ? 'row-' ~ loop.index) }}>
         {% for column in row.content %}
-          <div{{ column.attributes.addClass(col_classes, options.col_class_default ? 'col-' ~ loop.index) }}>
+          <div {{ column.attributes.addClass(col_classes, options.col_class_default ? 'col-' ~ loop.index) }}>
             {{- column.content -}}
           </div>
         {% endfor %}
@@ -64,9 +64,9 @@
     {% endfor %}
   {% else %}
     {% for column in items %}
-      <div{{ column.attributes.addClass(col_classes, options.col_class_default ? 'col-' ~ loop.index) }}>
+      <div {{ column.attributes.addClass(col_classes, options.col_class_default ? 'col-' ~ loop.index) }}>
         {% for row in column.content %}
-          <div{{ row.attributes.addClass(row_classes, options.row_class_default ? 'row-' ~ loop.index) }}>
+          <div {{ row.attributes.addClass(row_classes, options.row_class_default ? 'row-' ~ loop.index) }}>
             {{- row.content -}}
           </div>
         {% endfor %}

--- a/templates/views/views-view-list.html.twig
+++ b/templates/views/views-view-list.html.twig
@@ -22,7 +22,6 @@
   {% if title %}
     <h3>{{ title }}</h3>
   {% endif %}
-{#Prettier Ignore#}
   <{{ list.type }}{{ list.attributes }}>
 
     {% for row in rows %}

--- a/templates/views/views-view-list.html.twig
+++ b/templates/views/views-view-list.html.twig
@@ -17,16 +17,16 @@
  */
 #}
 {% if attributes -%}
-  <div{{ attributes }}>
+  <div {{ attributes }}>
 {% endif %}
   {% if title %}
     <h3>{{ title }}</h3>
   {% endif %}
-
+{#Prettier Ignore#}
   <{{ list.type }}{{ list.attributes }}>
 
     {% for row in rows %}
-      <li{{ row.attributes }}>
+      <li {{ row.attributes }}>
         {{- row.content -}}
       </li>
     {% endfor %}

--- a/templates/views/views-view-table.html.twig
+++ b/templates/views/views-view-table.html.twig
@@ -40,7 +40,7 @@
     sticky ? 'sticky-enabled',
   ]
 %}
-<table{{ attributes.addClass(classes) }}>
+<table {{ attributes.addClass(classes) }}>
   {% if caption_needed %}
     <caption>
     {% if caption %}
@@ -65,7 +65,7 @@
               ]
             %}
           {% endif %}
-          <th{{ column.attributes.addClass(column_classes).setAttribute('scope', 'col') }}>
+          <th {{ column.attributes.addClass(column_classes).setAttribute('scope', 'col') }}>
             {%- if column.wrapper_element -%}
               <{{ column.wrapper_element }}>
                 {%- if column.url -%}
@@ -88,7 +88,7 @@
   {% endif %}
   <tbody>
     {% for row in rows %}
-      <tr{{ row.attributes }}>
+      <tr {{ row.attributes }}>
         {% for key, column in row.columns %}
           {% if column.default_classes %}
             {%
@@ -100,7 +100,7 @@
               {% set column_classes = column_classes|merge(['views-field-' ~ field]) %}
             {% endfor %}
           {% endif %}
-          <td{{ column.attributes.addClass(column_classes) }}>
+          <td {{ column.attributes.addClass(column_classes) }}>
             {%- if column.wrapper_element -%}
               <{{ column.wrapper_element }}>
               {% for content in column.content %}

--- a/templates/views/views-view-unformatted.html.twig
+++ b/templates/views/views-view-unformatted.html.twig
@@ -24,7 +24,7 @@
       default_row_class ? 'views-row',
     ]
   %}
-  <div{{ row.attributes.addClass(row_classes) }}>
+  <div {{ row.attributes.addClass(row_classes) }}>
     {{- row.content -}}
   </div>
 {% endfor %}

--- a/templates/views/views-view.html.twig
+++ b/templates/views/views-view.html.twig
@@ -39,7 +39,7 @@
     dom_id ? 'js-view-dom-id-' ~ dom_id,
   ]
 %}
-<div{{ attributes.addClass(classes) }}>
+<div {{ attributes.addClass(classes) }}>
   {{ title_prefix }}
   {% if title %}
     {{ title }}


### PR DESCRIPTION
Fixes # [ZSW084-39](https://zucommunications.atlassian.net/browse/ZSW084-39)

## Changes Proposed in this Pull Request
- Added spaces between tags and `{{`
- e.g. `<div{{` will become `<div {{` 
- This is to resolve prettier errors

This PR is paired with [this PR](https://github.com/ZuCommunications/rapidkit/pull/53)

[ZSW084-39]: https://zucommunications.atlassian.net/browse/ZSW084-39?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ